### PR TITLE
Fix status reactions preventing an on_cascade delete

### DIFF
--- a/db/migrate/20221124114030_create_status_reactions.rb
+++ b/db/migrate/20221124114030_create_status_reactions.rb
@@ -1,10 +1,10 @@
 class CreateStatusReactions < ActiveRecord::Migration[6.1]
   def change
     create_table :status_reactions do |t|
-      t.references :account, null: false, foreign_key: true
-      t.references :status, null: false, foreign_key: true
+      t.references :account, null: false, foreign_key: { on_delete: :cascade }
+      t.references :status, null: false, foreign_key: { on_delete: :cascade }
       t.string :name, null: false, default: ''
-      t.references :custom_emoji, null: true, foreign_key: true
+      t.references :custom_emoji, null: true, foreign_key: { on_delete: :cascade }
 
       t.timestamps
     end


### PR DESCRIPTION
(Eerily enough, this is correct in the db schema, but not in the migration)